### PR TITLE
Mowing detection fixes

### DIFF
--- a/python/ts/mowingDetection/mowingDetection_UDF.py
+++ b/python/ts/mowingDetection/mowingDetection_UDF.py
@@ -189,7 +189,10 @@ def detectMow_S2_new(xs, ys,  clearWd, yr, type='ConHull', nOrder=3, model='line
         Y0 = np.min(Y0)
 
         if MoSIndex <= 2:
-            earlyPeak1 = np.nanmax(Y[0:MoSIndex])
+            if MoSIndex == 0:
+                earlyPeak1 = Y[0]
+            else:
+                earlyPeak1 = np.nanmax(Y[0:MoSIndex])
             earlyIndex1 = np.min(np.where(Y == earlyPeak1))
         else:
             searchInd = np.argwhere(X <= X[MoSIndex] - clearWd * 0.00273973)

--- a/python/ts/mowingDetection/mowingDetection_UDF.py
+++ b/python/ts/mowingDetection/mowingDetection_UDF.py
@@ -140,15 +140,11 @@ def detectMow_S2_new(xs, ys,  clearWd, yr, type='ConHull', nOrder=3, model='line
 
         SoGLS = np.where(SoGLSdiff == np.nanmin(SoGLSdiff))
 
-        if np.nanmin(SoGLSdiff) < Season_min_frac:
-            SoGLS = SoGLS[0] + 1
-
         EoGLS = np.abs(X - Season_max_frac)
         EoGLS = np.where(EoGLS == np.nanmin(EoGLS))
 
-
-        Y = np.asarray(Y[SoGLS[0]:EoGLS[0][0]])
-        X = np.asarray(X[SoGLS[0]:EoGLS[0][0]])
+        Y = np.asarray(Y[SoGLS[0][0]:EoGLS[0][0]])
+        X = np.asarray(X[SoGLS[0][0]:EoGLS[0][0]])
 
         # calculate NDVI difference (t1) - (t-1)
         yT1 = np.asarray(Y[1:])

--- a/python/ts/mowingDetection/mowingDetection_UDF.py
+++ b/python/ts/mowingDetection/mowingDetection_UDF.py
@@ -136,13 +136,11 @@ def detectMow_S2_new(xs, ys,  clearWd, yr, type='ConHull', nOrder=3, model='line
 
         ##############################################
 
+        # filter time series to season (check if needed or a code legacy)
         SoGLSdiff = np.abs(X - Season_min_frac)
-
         SoGLS = np.where(SoGLSdiff == np.nanmin(SoGLSdiff))
-
         EoGLS = np.abs(X - Season_max_frac)
         EoGLS = np.where(EoGLS == np.nanmin(EoGLS))
-
         Y = np.asarray(Y[SoGLS[0][0]:EoGLS[0][0]])
         X = np.asarray(X[SoGLS[0][0]:EoGLS[0][0]])
 

--- a/python/ts/mowingDetection/visualize_mowingDetection_UDF.py
+++ b/python/ts/mowingDetection/visualize_mowingDetection_UDF.py
@@ -5,6 +5,7 @@ from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QColor
 from enmapboxprocessing.utils import Utils
 import mowingDetection_UDF
+import importlib
 importlib.reload(mowingDetection_UDF)
 from mowingDetection_UDF import *
 import numpy as np


### PR DESCRIPTION
- The positioning of the first vertex was corrected. It was always moved to the second position, possibly due to code legacy. The time series is already filtered by season at this stage, but maybe this was not the case in previous versions.
-  Preventing a numpy zero-size error if MoSIndex==0
- Adding  missing import in the visualization module